### PR TITLE
Bugfix: venv copying

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+backend/.venv

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -6,9 +6,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 COPY backend/pyproject.toml backend/uv.lock* ./
 
-COPY backend/ .
-
 RUN uv sync --frozen
+
+COPY backend/ .
 
 ENV PATH="/app/.venv/bin:$PATH"
 


### PR DESCRIPTION
It appears that my local venv file was being mounted over the venv file being generated from uv sync in the docker file. This was causing commands to fail, using my local venv from backend rather than the one created from uv sync (I don't remember making a local .venv). I changed it by simple running the sync after copying the old backend, so the new .venv is used instead

@Jrodrigo06 I assume this didn't happen for you, we can also just create a .dockerignore and add /backend/.venv, which my first commit did.