### PR TITLE
Bugfix: order updates stock quantity jacob (task 1)

### DIFF
--- a/backend/examples/example_service_layer.py
+++ b/backend/examples/example_service_layer.py
@@ -142,6 +142,7 @@ class ChocolateService:
 
         Business rules:
         1. Check stock availability for all items
+        2. Stocks are only updated if every stock is available
         2. Calculate total price (sum of item_price * quantity)
         3. Apply bulk discount if order total > $50 (10% off)
         4. Create order record
@@ -157,6 +158,8 @@ class ChocolateService:
         """
         items = order_data["items"]
         total_price = Decimal("0.00")
+        chocolates_ordered = []
+        quantity_ordered = []
 
         for item in items:
             chocolate = await self.get_chocolate_by_id(item["chocolate_id"])
@@ -172,10 +175,14 @@ class ChocolateService:
                 )
 
             else:
-                chocolate["stock_quantity"] -= item["quantity"]
+                chocolates_ordered.append(chocolate)
+                quantity_ordered.append(item["quantity"])
 
             item_total = chocolate["price"] * item["quantity"]
             total_price += item_total
+
+        for index in range(len(chocolates_ordered)):
+            chocolates_ordered[index]["stock_quantity"] -= quantity_ordered[index]
 
         if total_price > Decimal("50.00"):
             total_price *= Decimal("0.90")  # 10% off

--- a/backend/tests/examples/test_example.py
+++ b/backend/tests/examples/test_example.py
@@ -164,6 +164,26 @@ class TestChocolateService:
         assert "Insufficient stock" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_sufficient_then_insufficient_stock(self, chocolate_service):
+        """
+        Test that when there is enough stock for the first chocolate but not the second chocolate,
+        that the first chocolate does not have its quantity changed.
+        """
+        order_data = {
+            "customer_name": "Bob",
+            "items": [
+                {"chocolate_id": 1, "quantity": 3},
+                {"chocolate_id": 2, "quantity": 10},  # Only 5 in stock...
+            ],
+        }
+
+        # Expecting an error as we are ordering tm
+        with pytest.raises(ValueError):
+            await chocolate_service.create_order(order_data)
+
+        assert CHOCOLATES[0]["stock_quantity"] == 50
+
+    @pytest.mark.asyncio
     async def test_check_low_stock(self, chocolate_service):
         """
         Test the low stock alert functionality.


### PR DESCRIPTION
## Description

What does this PR do?
<!-- Brief description of the changes -->
I made it so that if the amount of chocolate being ordered is less than or equal to the stock_quantity, it subtracts that amount of supply from stock_quantity. Otherwise, it says there is insufficient supply and does not remove the chocolate from the DB.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

In the test for a successful order being placed, I check that the stock_quantity for each chocolate ordered updates correctly (1 and 2, respectively). Similarly, in the test for an order with insufficient stock, I check that the stock_quantity does not change.

## Checklist:
<!-- [x] indicates a checked off item -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules